### PR TITLE
Fix relative lineTo

### DIFF
--- a/svg2shape/SVG Path to Shape.diamond/resources/16451519990821953008.js
+++ b/svg2shape/SVG Path to Shape.diamond/resources/16451519990821953008.js
@@ -63,7 +63,6 @@ function svgToJSONPath(pathStr)  {
       } else {
         cursor = {"x":command[1],"y":command[2]};
       }
-      cursor = {"x":command[1],"y":command[2]};
       object.push({"type":"lineTo", "point" : cursor});
     } else if (command[0] === 'H' || command[0] === 'h') { // Horizontal Line
       if (command[0] === 'h') { // Horizontal relative mode


### PR DESCRIPTION
This extra `cursor = {"x":command[1],"y":command[2]};` was overwriting the absolute/relative branching up above, causing all relative `lineTo` commands to be treated as absolute.